### PR TITLE
Fix initialization of relays

### DIFF
--- a/src/hubot-slack-relay.coffee
+++ b/src/hubot-slack-relay.coffee
@@ -19,7 +19,7 @@ Relay = require './relay'
 module.exports = (robot) ->
 
   BRAIN_KEY = 'hubot-slack-relay.storage'
-  relays = {}
+  relays = []
 
   brainLoaded = () =>
     #load brain data


### PR DESCRIPTION
Without this change, newly set up instances fail when adding the first relay with the error: Note, relay list may need a change to show the right thing when the list is empty.

ERROR TypeError: undefined is not a function
  at RemoteSlack.newRemoteConnected (/home/hubot/node_modules/hubot-slack-relay/src/hubot-slack-relay.coffee:95:7, <js>:80:16)
